### PR TITLE
Fetch model items by lang

### DIFF
--- a/src/actions/find-and-replace/find-and-replace.test.js
+++ b/src/actions/find-and-replace/find-and-replace.test.js
@@ -6,7 +6,7 @@ const test = require("ava");
 const authContext = require("../../../test/helpers/auth-context");
 test.beforeEach(authContext);
 
-const MODEL_ZUID = "6-8ca8dccef4-4w7r5w";
+const MODEL_ZUID = "6-a0f4b7b0f8-fcwk35";
 const FIELD_NAME = "content";
 const PATTERN = "TOKEN";
 const REPLACEMENT = "REPLACED";

--- a/src/services/instance/items/index.js
+++ b/src/services/instance/items/index.js
@@ -5,7 +5,8 @@ const UTC_FORMAT = "YYYY-MM-DD HH:mm:ss";
 
 module.exports = {
   API: {
-    fetchItems: "/content/models/MODEL_ZUID/items?page=PAGE&limit=LIMIT",
+    fetchItems:
+      "/content/models/MODEL_ZUID/items?page=PAGE&limit=LIMIT&lang=LANG",
     fetchItem: "/content/models/MODEL_ZUID/items/ITEM_ZUID",
     fetchItemPublishings:
       "/content/models/MODEL_ZUID/items/ITEM_ZUID/publishings",
@@ -34,7 +35,12 @@ module.exports = {
   },
   mixin: (superclass) =>
     class Item extends superclass {
-      async getItems(modelZUID) {
+      async getItems(
+        modelZUID,
+        opt = {
+          lang: "en-US",
+        }
+      ) {
         if (!modelZUID) {
           throw new Error(
             "SDK:Instance:getItems() missing required `modelZUID` argument"
@@ -56,6 +62,7 @@ module.exports = {
               MODEL_ZUID: modelZUID,
               PAGE: page,
               LIMIT: limit,
+              LANG: opt.lang,
             })
           );
 


### PR DESCRIPTION
adds an options object to the `fetchItems` function with a default language of `en-US`. This will allow for consumers to define a language which they would like to fetch model items by.