### PR TITLE
Add support for lower environment for media APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ ZESTY_AUTH_API=
 ZESTY_ACCOUNTS_API=
 ZESTY_INSTANCE_API=
 ZESTY_MEDIA_API=
+ZESTY_MEDIA_STORAGE_API=
 ZESTY_COOKIE=
 
 // The included SDK tests require providing resource ZUIDs to run against

--- a/src/sdk.test.js
+++ b/src/sdk.test.js
@@ -33,10 +33,11 @@ test("authenticated", async (t) => {
 
 test("init with options", async (t) => {
   const opts = {
-    accountsAPIURL: "https://accounts.api.dev.zesty.io/v1/",
-    authURL: "https://auth.api.dev.zesty.io/v1/",
+    accountsAPIURL: "https://accounts.api.dev.zesty.io/v1",
+    authURL: "https://auth.api.dev.zesty.io",
     instancesAPIURL: "https://INSTANCE_ZUID.api.dev.zesty.io/v1",
-    mediaAPIURL: "https://svc.dev.zesty.io",
+    mediaAPIURL: "https://media-manager.api.dev.zesty.io",
+    mediaStorageAPIURL: "https://media-storage.api.dev.zesty.io",
   };
   const token = await getToken();
   const sdk = new SDK(process.env.ZESTY_INSTANCE_ZUID, token, opts);

--- a/src/services/media/media.js
+++ b/src/services/media/media.js
@@ -9,26 +9,32 @@ module.exports = class Media extends Service {
     const baseAPI =
       options.mediaAPIURL ||
       process.env.ZESTY_MEDIA_API ||
-      `https://`;
+      `https://media-manager.api.zesty.io`;
 
     super(baseAPI, token);
 
+    // Base API for media storage/upload
+    this.storageAPI =
+      options.mediaStorageAPIURL ||
+      process.env.ZESTY_MEDIA_STORAGE_API ||
+      `https://media-storage.api.zesty.io`;
+
     this.API = {
-      fetchBin: "media-manager.api.zesty.io/bin/BIN_ZUID",
-      fetchBins: "media-manager.api.zesty.io/site/SITE_ID/bins",
-      updateBin: "media-manager.api.zesty.io/bin/BIN_ZUID",
+      fetchBin: "/bin/BIN_ZUID",
+      fetchBins: "/site/SITE_ID/bins",
+      updateBin: "/bin/BIN_ZUID",
 
-      fetchFile: "media-manager.api.zesty.io/file/FILE_ZUID",
-      fetchFiles: "media-manager.api.zesty.io/bin/BIN_ZUID/files",
-      createFile: "media-storage.api.zesty.io/upload/STORAGE_PROVIDER/STORAGE_LOCATION",
-      updateFile: "media-manager.api.zesty.io/file/FILE_ZUID",
-      deleteFile: "media-manager.api.zesty.io/file/FILE_ZUID",
+      fetchFile: "/file/FILE_ZUID",
+      fetchFiles: "/bin/BIN_ZUID/files",
+      createFile: "/upload/STORAGE_PROVIDER/STORAGE_LOCATION",
+      updateFile: "/file/FILE_ZUID",
+      deleteFile: "/file/FILE_ZUID",
 
-      fetchGroup: "media-manager.api.zesty.io/group/GROUP_ZUID",
-      fetchGroups: "media-manager.api.zesty.io/bin/BIN_ZUID/groups",
-      createGroup: "media-manager.api.zesty.io/group",
-      updateGroup: "media-manager.api.zesty.io/group/GROUP_ZUID",
-      deleteGroup: "media-manager.api.zesty.io/group/GROUP_ZUID",
+      fetchGroup: "/group/GROUP_ZUID",
+      fetchGroups: "/bin/BIN_ZUID/groups",
+      createGroup: "/group",
+      updateGroup: "/group/GROUP_ZUID",
+      deleteGroup: "/group/GROUP_ZUID",
     };
 
     // Needed to support lookup of instance ZUID for legacy API support
@@ -161,6 +167,7 @@ module.exports = class Media extends Service {
         STORAGE_LOCATION: bin.data[0].storage_name,
       }),
       {
+        baseAPI: this.storageAPI,
         isFormData: true,
         payload,
       }

--- a/src/services/service.js
+++ b/src/services/service.js
@@ -93,7 +93,8 @@ module.exports = class Service {
       throw new Error("Missing required `path`. Can not make request.");
     }
 
-    const uri = `${this.baseAPI}${path}`;
+    const base = params.baseAPI || this.baseAPI;
+    const uri = `${base}${path}`;
     const opts = {
       method: params.method,
       headers: {},


### PR DESCRIPTION
Closes #75 

This PR allows configuring the sdk to use the lower environment for the media APIs. Since the `createFile` API uses the `media-storage-service` while the other media APIs use `media-manager-service`, added the sdk option for passing the base APIs for both media services. 

This code change will be used for allow to use  the sdk in dev and stage, helpful for testing.