### PR TITLE
add field hard deletion and update test for field deletion

### DIFF
--- a/src/services/instance/fields/fields.test.js
+++ b/src/services/instance/fields/fields.test.js
@@ -73,8 +73,8 @@ test.serial("patchField:200", async(t) => {
   t.truthy(res.data.ZUID);
 });
 
-// Field deletion is only a soft-delete so need to skip this test to stop overpopulating the database by adding more columns without actually deleting them
-test.skip("deleteField:200", async(t) => {
+// Field deletion is only a soft-delete so need to also run field hard deletion to stop overpopulating the database by adding more columns without actually deleting them
+test("deleteField:200", async(t) => {
   const name = `node-sdk_createItem_${moment().valueOf()}`;
   let res = await t.context.sdk.instance.createField(
     process.env.TEST_MODEL_ZUID,
@@ -87,15 +87,20 @@ test.skip("deleteField:200", async(t) => {
       }
     }
   )
+
   t.is(res.statusCode, 201);
   t.truthy(res.data.ZUID);
-
   const newFieldZUID = res.data.ZUID;
 
   res = await t.context.sdk.instance.deleteModelField(
     process.env.TEST_MODEL_ZUID,
     newFieldZUID
   );
+  t.is(res.statusCode, 200);
 
+  res = await t.context.sdk.instance.hardDeleteModelField(
+    process.env.TEST_MODEL_ZUID,
+    newFieldZUID
+  );
   t.is(res.statusCode, 200);
 });

--- a/src/services/instance/fields/fields.test.js
+++ b/src/services/instance/fields/fields.test.js
@@ -76,7 +76,7 @@ test.serial("patchField:200", async(t) => {
 // Field deletion is only a soft-delete so need to also run field hard deletion to stop overpopulating the database by adding more columns without actually deleting them
 test("deleteField:200", async(t) => {
   const name = `node-sdk_createItem_${moment().valueOf()}`;
-  let res = await t.context.sdk.instance.createField(
+  const createRes = await t.context.sdk.instance.createField(
     process.env.TEST_MODEL_ZUID,
     {
       datatype : "text",
@@ -88,19 +88,21 @@ test("deleteField:200", async(t) => {
     }
   )
 
-  t.is(res.statusCode, 201);
-  t.truthy(res.data.ZUID);
-  const newFieldZUID = res.data.ZUID;
+  t.is(createRes.statusCode, 201);
+  t.truthy(createRes.data.ZUID);
+  const newFieldZUID = createRes.data.ZUID;
 
-  res = await t.context.sdk.instance.deleteModelField(
+  const deleteRes = await t.context.sdk.instance.deleteModelField(
     process.env.TEST_MODEL_ZUID,
     newFieldZUID
   );
-  t.is(res.statusCode, 200);
+  t.is(deleteRes.statusCode, 200);
 
-  res = await t.context.sdk.instance.hardDeleteModelField(
+  // hard delete
+  const hardDeleteRes = await t.context.sdk.instance.deleteModelField(
     process.env.TEST_MODEL_ZUID,
-    newFieldZUID
+    newFieldZUID, 
+    true
   );
-  t.is(res.statusCode, 200);
+  t.is(hardDeleteRes.statusCode, 200);
 });

--- a/src/services/instance/fields/fields.test.js
+++ b/src/services/instance/fields/fields.test.js
@@ -45,7 +45,7 @@ test.skip("createField:201", async(t) => {
 
 // skip this test to stop for overpopulating the database by adding more columns without deleting them
 test.serial("updateField:200", async(t) => {
-  const name = `node-sdk_updateItem_${moment().valueOf()}`;
+  const name = `node_sdk_updateItem_${moment().valueOf()}`;
   const res = await t.context.sdk.instance.updateModelField(
     process.env.TEST_MODEL_ZUID,
     process.env.TEST_FIELD_ZUID,
@@ -61,7 +61,7 @@ test.serial("updateField:200", async(t) => {
 });
 
 test.serial("patchField:200", async(t) => {
-  const name = `node-sdk_patchItem_${moment().valueOf()}`;
+  const name = `node_sdk_patchItem_${moment().valueOf()}`;
   const res = await t.context.sdk.instance.patchModelField(
     process.env.TEST_MODEL_ZUID,
     process.env.TEST_FIELD_ZUID,
@@ -75,7 +75,7 @@ test.serial("patchField:200", async(t) => {
 
 // Field deletion is only a soft-delete so need to also run field hard deletion to stop overpopulating the database by adding more columns without actually deleting them
 test("deleteField:200", async(t) => {
-  const name = `node-sdk_createItem_${moment().valueOf()}`;
+  const name = `node_sdk_createItem_${moment().valueOf()}`;
   const createRes = await t.context.sdk.instance.createField(
     process.env.TEST_MODEL_ZUID,
     {

--- a/src/services/instance/fields/index.js
+++ b/src/services/instance/fields/index.js
@@ -117,7 +117,7 @@ module.exports = {
         );
       }
 
-      async deleteModelField(modelZUID, fieldZUID, hardDelete = "false") {
+      async deleteModelField(modelZUID, fieldZUID, hardDelete = false) {
         if (!modelZUID) {
           throw new Error(
             "SDK:Instance:deleteModelField() missing required `modelZUID` argument"

--- a/src/services/instance/fields/index.js
+++ b/src/services/instance/fields/index.js
@@ -7,7 +7,8 @@ module.exports = {
     createFieldPath: "/content/models/MODEL_ZUID/fields",
     updateModelField: "/content/models/MODEL_ZUID/fields/FIELD_ZUID",
     patchModelField: "/content/models/MODEL_ZUID/fields/FIELD_ZUID",
-    deleteModelField: "/content/models/MODEL_ZUID/fields/FIELD_ZUID"
+    deleteModelField: "/content/models/MODEL_ZUID/fields/FIELD_ZUID",
+    hardDeleteModelField: "/content/models/MODEL_ZUID/fields/FIELD_ZUID?hardDelete=true"
   },
   mixin: superclass =>
     class Field extends superclass {
@@ -131,6 +132,26 @@ module.exports = {
 
         return await this.deleteRequest(
           this.interpolate(this.API.deleteModelField, {
+            MODEL_ZUID: modelZUID,
+            FIELD_ZUID: fieldZUID
+          })
+        );
+      }
+
+      async hardDeleteModelField(modelZUID, fieldZUID) {
+        if (!modelZUID) {
+          throw new Error(
+            "SDK:Instance:deleteModelField() missing required `modelZUID` argument"
+          );
+        }
+        if (!fieldZUID) {
+          throw new Error(
+            "SDK:Instance:deleteModelField() missing required `fieldZUID` argument"
+          );
+        }
+
+        return await this.deleteRequest(
+          this.interpolate(this.API.hardDeleteModelField, {
             MODEL_ZUID: modelZUID,
             FIELD_ZUID: fieldZUID
           })

--- a/src/services/instance/fields/index.js
+++ b/src/services/instance/fields/index.js
@@ -7,8 +7,7 @@ module.exports = {
     createFieldPath: "/content/models/MODEL_ZUID/fields",
     updateModelField: "/content/models/MODEL_ZUID/fields/FIELD_ZUID",
     patchModelField: "/content/models/MODEL_ZUID/fields/FIELD_ZUID",
-    deleteModelField: "/content/models/MODEL_ZUID/fields/FIELD_ZUID",
-    hardDeleteModelField: "/content/models/MODEL_ZUID/fields/FIELD_ZUID?hardDelete=true"
+    deleteModelField: "/content/models/MODEL_ZUID/fields/FIELD_ZUID?hardDelete=HARD_DELETE"
   },
   mixin: superclass =>
     class Field extends superclass {
@@ -118,7 +117,7 @@ module.exports = {
         );
       }
 
-      async deleteModelField(modelZUID, fieldZUID) {
+      async deleteModelField(modelZUID, fieldZUID, hardDelete = "false") {
         if (!modelZUID) {
           throw new Error(
             "SDK:Instance:deleteModelField() missing required `modelZUID` argument"
@@ -129,31 +128,12 @@ module.exports = {
             "SDK:Instance:deleteModelField() missing required `fieldZUID` argument"
           );
         }
-
+ 
         return await this.deleteRequest(
           this.interpolate(this.API.deleteModelField, {
             MODEL_ZUID: modelZUID,
-            FIELD_ZUID: fieldZUID
-          })
-        );
-      }
-
-      async hardDeleteModelField(modelZUID, fieldZUID) {
-        if (!modelZUID) {
-          throw new Error(
-            "SDK:Instance:deleteModelField() missing required `modelZUID` argument"
-          );
-        }
-        if (!fieldZUID) {
-          throw new Error(
-            "SDK:Instance:deleteModelField() missing required `fieldZUID` argument"
-          );
-        }
-
-        return await this.deleteRequest(
-          this.interpolate(this.API.hardDeleteModelField, {
-            MODEL_ZUID: modelZUID,
-            FIELD_ZUID: fieldZUID
+            FIELD_ZUID: fieldZUID,
+            HARD_DELETE: hardDelete
           })
         );
       }


### PR DESCRIPTION
Closes  #70 

This PR adds support for field hard deletion as this is already supported (see [docs](https://docs.zesty.io/reference/delete-field)) using the `hardDelete` query param.

This PR also adds back field deletion in the test suite as the field will now be hard deleted in the database, to prevent the `Row size too large` database error encountered when a lot of fields are created for a model (a new field creates a new column in the model record). 

The name for the fields test is also updated to follow the validation logic in the `instances-api` fields creation which does not allow a field name to contain any other characters other than letters, numbers and underscores.